### PR TITLE
Add frontend and backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # test_chatbot
 A test project for LLM chatbot
+
+## Backend Setup
+
+To install dependencies:
+```bash
+pip install -r backend/requirements.txt
+```
+
+To run the development server:
+```bash
+uvicorn backend.app:app --reload
+```
+
+## Frontend Setup
+
+Open `frontend/index.html` in your browser. The page uses CDN links for React and does not require a build step.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+class ChatRequest(BaseModel):
+    message: str
+
+class ChatResponse(BaseModel):
+    response: str
+
+app = FastAPI()
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest):
+    # For now, just return example response
+    return ChatResponse(response=f"Echo: {req.message}")
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Data Analysis Chatbot</title>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body, html { height: 100%; margin: 0; font-family: Arial, sans-serif; }
+    #root { display: flex; height: 100%; }
+    .sidebar { width: 30%; display: flex; flex-direction: column; border-right: 1px solid #ccc; padding: 10px; box-sizing: border-box; }
+    .upload-section { flex: 1; overflow: auto; }
+    .plan-section { flex: 1; overflow: auto; border-top: 1px solid #ccc; margin-top: 10px; padding-top: 10px; }
+    .chat-section { flex: 1; display: flex; flex-direction: column; width: 70%; }
+    .messages { flex: 1; overflow-y: auto; padding: 10px; }
+    .input-area { display: flex; }
+    .input-area input { flex: 1; padding: 10px; }
+    .input-area button { padding: 10px; }
+    ul { list-style: none; padding: 0; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const {{ useState }} = React;
+
+    function App() {{
+      const [files, setFiles] = useState([]);
+      const [selectedFile, setSelectedFile] = useState(null);
+      const [messages, setMessages] = useState([]);
+      const [analysisPlan, setAnalysisPlan] = useState([]);
+      const [input, setInput] = useState('');
+
+      const handleUpload = (e) => {{
+        const fileList = Array.from(e.target.files);
+        const newFiles = fileList.map(f => ({{ name: f.name }}));
+        setFiles([...files, ...newFiles]);
+        e.target.value = null; // reset input
+      }};
+
+      const handleFileSelect = (name) => {{
+        setSelectedFile(name);
+      }};
+
+      const sendMessage = async () => {{
+        if (!input.trim()) return;
+        const userMsg = {{ sender: 'user', text: input }};
+        setMessages([userMsg, ...messages]);
+        setInput('');
+        // Example API call
+        const res = await fetch('/chat', {{
+          method: 'POST',
+          headers: {{ 'Content-Type': 'application/json' }},
+          body: JSON.stringify({{ message: input }})
+        }});
+        const data = await res.json();
+        const botMsg = {{ sender: 'bot', text: data.response }};
+        setMessages([botMsg, userMsg, ...messages]);
+        // Example analysis plan update
+        setAnalysisPlan(['Step 1: ...', 'Step 2: ...']);
+      }};
+
+      return (
+        <div id="container" style={{ display: 'flex', height: '100%', width: '100%' }}>
+          <div className="sidebar">
+            <div className="upload-section">
+              <h3>Upload Files</h3>
+              <input type="file" accept=".csv" multiple onChange={handleUpload} />
+              <ul>
+                {{files.map(f => (
+                  <li key={f.name}>
+                    <label>
+                      <input type="checkbox" checked={selectedFile === f.name} onChange={() => handleFileSelect(f.name)} />
+                      {{f.name}}
+                    </label>
+                  </li>
+                ))}}
+              </ul>
+            </div>
+            <div className="plan-section">
+              <h3>Analysis Plan</h3>
+              <ol>
+                {{analysisPlan.map((step, i) => <li key={i}>{{step}}</li>)}}
+              </ol>
+            </div>
+          </div>
+          <div className="chat-section">
+            <div className="messages">
+              {{messages.map((m, i) => (
+                <div key={i}><strong>{{m.sender}}:</strong> {{m.text}}</div>
+              ))}}
+            </div>
+            <div className="input-area">
+              <input value={input} onChange={e => setInput(e.target.value)} onKeyDown={e => e.key==='Enter' && sendMessage()} />
+              <button onClick={sendMessage}>Send</button>
+            </div>
+          </div>
+        </div>
+      );
+    }}
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a minimal FastAPI backend with a `/chat` endpoint
- add a simple React-based UI for chatting and file upload
- document how to run the backend and open the frontend

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847a664c340832b9da3aaf87a90d75a